### PR TITLE
Add culture tile feature: questions, labels, timer sync, score result

### DIFF
--- a/src/components/board/Board.tsx
+++ b/src/components/board/Board.tsx
@@ -3,7 +3,7 @@ import { useGame } from "../../context/GameContext";
 import Cell from "./Cell";
 import BoardCanvas from "./BoardCanvas";
 import PlayerToken from "./PlayerToken";
-import { TOTAL_CELLS, SPIRAL_PATH, CATEGORIES } from "../../lib/constants";
+import { TOTAL_CELLS, SPIRAL_PATH, CATEGORIES, CULTURE_POSITIONS } from "../../lib/constants";
 
 export default function Board() {
   const state = useGame();
@@ -45,8 +45,10 @@ export default function Board() {
         const isStart = pathIndex === 0;
         const isFinish = pathIndex === SPIRAL_PATH.length - 1;
 
+        const isCulture = isOnPath && !isStart && !isFinish && CULTURE_POSITIONS.has(pathIndex!);
+
         let category: string | null = null;
-        if (isOnPath && !isStart && !isFinish) {
+        if (isOnPath && !isStart && !isFinish && !isCulture) {
           category = CATEGORIES[pathIndex % CATEGORIES.length];
         }
 
@@ -78,6 +80,7 @@ export default function Board() {
             isOnPath={isOnPath}
             isStart={isStart}
             isFinish={isFinish}
+            isCulture={isCulture}
             category={category}
             connectClass={connectClass}
             debugMode={state.debugMode}

--- a/src/components/board/Cell.tsx
+++ b/src/components/board/Cell.tsx
@@ -9,6 +9,7 @@ interface CellProps {
   isOnPath: boolean;
   isStart: boolean;
   isFinish: boolean;
+  isCulture: boolean;
   category: string | null;
   connectClass: string;
   debugMode: boolean;
@@ -16,7 +17,7 @@ interface CellProps {
 
 const Cell = forwardRef<HTMLDivElement, CellProps>(
   (
-    { pathIndex, isOnPath, isStart, isFinish, category, debugMode },
+    { pathIndex, isOnPath, isStart, isFinish, isCulture, category, debugMode },
     ref
   ) => {
     if (!isOnPath) {
@@ -28,17 +29,23 @@ const Cell = forwardRef<HTMLDivElement, CellProps>(
       ? "bg-white text-black"
       : isFinish
         ? "bg-amber-400 text-black"
-        : category
-          ? CATEGORY_BG_COLORS[category as Category]
-          : "bg-white";
+        : isCulture
+          ? "bg-fuchsia-600 text-white"
+          : category
+            ? CATEGORY_BG_COLORS[category as Category]
+            : "bg-white";
 
     const label = isStart
       ? "START"
       : isFinish
         ? "FINISH"
-        : debugMode && pathIndex !== undefined
-          ? String(pathIndex)
-          : "";
+        : isCulture
+          ? debugMode && pathIndex !== undefined
+            ? String(pathIndex)
+            : "★"
+          : debugMode && pathIndex !== undefined
+            ? String(pathIndex)
+            : "";
 
     return (
       <div
@@ -48,7 +55,14 @@ const Cell = forwardRef<HTMLDivElement, CellProps>(
           bgColor
         )}
       >
-        {label}
+        {isCulture && !(debugMode && pathIndex !== undefined) ? (
+          <div className="flex flex-col items-center leading-none gap-0.5">
+            <span>★</span>
+            <span className="text-[0.65em]">Culture</span>
+          </div>
+        ) : (
+          label
+        )}
       </div>
     );
   }

--- a/src/components/layout/GameLayout.tsx
+++ b/src/components/layout/GameLayout.tsx
@@ -6,6 +6,7 @@ import Board from "../board/Board";
 import QuestionModal from "../modals/QuestionModal";
 import WinModal from "../modals/WinModal";
 import QuestionEditor from "../modals/QuestionEditor";
+import CultureModal from "../modals/CultureModal";
 import type { Question } from "../../types/game";
 
 import filmData from "../../data/film.json";
@@ -30,7 +31,7 @@ export default function GameLayout() {
 
   // Body scroll lock when modals open
   useEffect(() => {
-    if (state.showQuestionModal || state.showEditor || state.showWinModal) {
+    if (state.showQuestionModal || state.showEditor || state.showWinModal || state.showCultureModal) {
       document.body.style.overflow = "hidden";
     } else {
       document.body.style.overflow = "";
@@ -38,7 +39,7 @@ export default function GameLayout() {
     return () => {
       document.body.style.overflow = "";
     };
-  }, [state.showQuestionModal, state.showEditor, state.showWinModal]);
+  }, [state.showQuestionModal, state.showEditor, state.showWinModal, state.showCultureModal]);
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-between p-2.5 lg:flex-row lg:items-start lg:justify-center lg:gap-10">
@@ -49,6 +50,7 @@ export default function GameLayout() {
       {state.showQuestionModal && state.activeQuestion && <QuestionModal />}
       {state.showWinModal && <WinModal />}
       {state.showEditor && <QuestionEditor />}
+      {state.showCultureModal && <CultureModal />}
     </div>
   );
 }

--- a/src/components/modals/CultureModal.tsx
+++ b/src/components/modals/CultureModal.tsx
@@ -1,0 +1,279 @@
+import { useState, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { useGame, useGameDispatch } from "../../context/GameContext";
+import { useGameLogicContext } from "../../context/GameLogicContext";
+import { useOnline } from "../../context/OnlineContext";
+import { TextureCard } from "../ui/TextureCard";
+import { TextureButton } from "../ui/TextureButton";
+import { CULTURE_TIMER_SECONDS } from "../../lib/constants";
+import { startCultureTimer, submitCultureScore } from "../../firebase/roomService";
+import cultureData from "../../data/culture.json";
+
+interface CultureQuestion {
+  id: string;
+  question: string;
+  answers: string[];
+}
+
+export default function CultureModal() {
+  const state = useGame();
+  const dispatch = useGameDispatch();
+  const { handleCultureScore } = useGameLogicContext();
+  const { identity } = useOnline();
+
+  // Local-mode phase tracking (online derives phase from state.cultureTimerStartedAt)
+  const [localPhase, setLocalPhase] = useState<"waiting" | "timer">("waiting");
+  const [timeLeft, setTimeLeft] = useState(CULTURE_TIMER_SECONDS);
+  const [checked, setChecked] = useState<boolean[]>(new Array(10).fill(false));
+  // Local-mode score result (online uses state.cultureScore)
+  const [localScore, setLocalScore] = useState<number | null>(null);
+
+  const activePlayer = state.players[state.currentPlayerIndex];
+
+  const isOnlineActive =
+    state.gameMode === "online" &&
+    identity.playerName !== null &&
+    activePlayer?.name === identity.playerName;
+
+  const questions = cultureData as CultureQuestion[];
+  const seed =
+    state.currentPlayerIndex +
+    (state.players[state.currentPlayerIndex]?.position ?? 0);
+  const question = questions[seed % questions.length];
+
+  // Derive phase: online clients use the Firebase-synced timestamp; local uses local state
+  const phase =
+    state.gameMode === "online"
+      ? state.cultureTimerStartedAt
+        ? "timer"
+        : "waiting"
+      : localPhase;
+
+  const score = checked.filter(Boolean).length;
+  const timerDone = phase === "timer" && timeLeft === 0;
+
+  // Score result: online reads from game state (set for all clients by hooks.ts), local from local state
+  const scoreResult =
+    state.gameMode === "online" ? state.cultureScore : localScore;
+  const showResult = scoreResult !== null;
+
+  const toggleAnswer = (i: number) =>
+    setChecked((prev) => prev.map((v, idx) => (idx === i ? !v : v)));
+
+  // Local-mode countdown
+  useEffect(() => {
+    if (state.gameMode === "online" || localPhase !== "timer") return;
+
+    const interval = setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 1) {
+          clearInterval(interval);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [localPhase, state.gameMode]);
+
+  // Online-mode countdown — derived from the shared Firebase timestamp so all clients stay in sync
+  useEffect(() => {
+    if (state.gameMode !== "online" || !state.cultureTimerStartedAt) return;
+
+    const update = () => {
+      const elapsed = Math.floor((Date.now() - state.cultureTimerStartedAt!) / 1000);
+      setTimeLeft(Math.max(0, CULTURE_TIMER_SECONDS - elapsed));
+    };
+
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [state.cultureTimerStartedAt, state.gameMode]);
+
+  // Reset checkboxes when a fresh timer starts (online)
+  useEffect(() => {
+    if (state.gameMode === "online" && state.cultureTimerStartedAt) {
+      setChecked(new Array(10).fill(false));
+    }
+  }, [state.cultureTimerStartedAt, state.gameMode]);
+
+  const handleStartTimer = () => {
+    if (state.gameMode === "online" && identity.roomCode) {
+      // Write timestamp to Firebase — hooks.ts will dispatch SET_CULTURE_TIMER_START to all clients
+      startCultureTimer(identity.roomCode);
+    } else {
+      setTimeLeft(CULTURE_TIMER_SECONDS);
+      setChecked(new Array(10).fill(false));
+      setLocalPhase("timer");
+    }
+  };
+
+  const handleSubmit = () => {
+    if (state.gameMode === "online" && identity.roomCode) {
+      // hooks.ts will dispatch SET_CULTURE_SCORE to all clients so everyone sees the result
+      submitCultureScore(identity.roomCode, score);
+    } else {
+      setLocalScore(score);
+    }
+  };
+
+  const handleContinue = () => {
+    handleCultureScore(scoreResult!);
+  };
+
+  if (!activePlayer || !question) return null;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/85"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+      >
+        <motion.div
+          initial={{ scale: 0.9, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          exit={{ scale: 0.9, opacity: 0 }}
+          className="w-[340px] max-w-[95vw]"
+        >
+          <TextureCard className="max-h-[85vh] overflow-y-auto">
+            <h2 className="mb-4 text-center text-xl font-bold text-fuchsia-400">
+              ★ Culture Tile!
+            </h2>
+
+            {/* ── Result screen — shown to all clients once score is known ── */}
+            {showResult ? (
+              <div className="flex flex-col items-center gap-4">
+                <p className="text-4xl font-bold text-fuchsia-400">
+                  {scoreResult} / 10
+                </p>
+                <p className="text-center text-base font-semibold">
+                  {activePlayer.name} scored{" "}
+                  <span className="text-fuchsia-400">{scoreResult}</span>!
+                </p>
+                <p className="text-center text-sm opacity-60">
+                  {scoreResult! > 0
+                    ? `Moving forward ${scoreResult} space${scoreResult === 1 ? "" : "s"}…`
+                    : "No spaces gained."}
+                </p>
+                {/* Only the active player (online) or the local player can trigger movement */}
+                {(isOnlineActive || state.gameMode === "local") && (
+                  <TextureButton variant="primary" onClick={handleContinue}>
+                    Continue
+                  </TextureButton>
+                )}
+              </div>
+            ) : isOnlineActive ? (
+              /* ── Active player view (online only): question + synced countdown ── */
+              <div className="flex flex-col items-center gap-4">
+                <p className="text-center text-sm opacity-80">
+                  You've landed on a Culture tile — start reciting!
+                </p>
+                <p className="text-center text-sm font-semibold">
+                  {question.question}
+                </p>
+                {phase === "waiting" && (
+                  <p className="text-center text-xs opacity-60">
+                    Waiting for the judge to start the timer…
+                  </p>
+                )}
+                {phase === "timer" && (
+                  <>
+                    {timeLeft > 0 ? (
+                      <>
+                        <div className="text-6xl font-bold text-fuchsia-400">
+                          {timeLeft}
+                        </div>
+                        <p className="text-center text-xs opacity-60">
+                          seconds remaining
+                        </p>
+                      </>
+                    ) : (
+                      <p className="text-center text-lg font-bold text-fuchsia-400">
+                        Time's up!
+                      </p>
+                    )}
+                  </>
+                )}
+              </div>
+            ) : phase === "waiting" ? (
+              /* ── Judge / local — waiting phase ── */
+              <div className="flex flex-col items-center gap-4">
+                <p className="text-center text-sm opacity-80">
+                  <strong>{activePlayer.name}</strong> is performing.
+                  <br />
+                  Start the timer when they're ready.
+                </p>
+                <p className="w-full rounded-lg bg-fuchsia-950/50 p-3 text-center text-sm font-semibold text-fuchsia-200">
+                  {question.question}
+                </p>
+                <TextureButton onClick={handleStartTimer}>
+                  Start Timer
+                </TextureButton>
+              </div>
+            ) : (
+              /* ── Judge / local — timer phase: answers + countdown + submit ── */
+              <div className="flex flex-col gap-3">
+                <p className="text-center text-xs opacity-60">
+                  Tick answers as{" "}
+                  <strong className="opacity-100">{activePlayer.name}</strong>{" "}
+                  names them
+                </p>
+
+                <p className="rounded-lg bg-fuchsia-950/50 p-2 text-center text-xs font-semibold text-fuchsia-200">
+                  {question.question}
+                </p>
+
+                {/* Countdown */}
+                <div className="flex items-center justify-center gap-2">
+                  {timeLeft > 0 ? (
+                    <>
+                      <span className="text-4xl font-bold text-fuchsia-400">
+                        {timeLeft}
+                      </span>
+                      <span className="text-xs opacity-60">sec</span>
+                    </>
+                  ) : (
+                    <span className="text-sm font-bold text-fuchsia-400">
+                      Time's up!
+                    </span>
+                  )}
+                </div>
+
+                {/* Answer list */}
+                <ol className="flex flex-col gap-1">
+                  {question.answers.map((answer, i) => (
+                    <li key={i}>
+                      <button
+                        onClick={() => toggleAnswer(i)}
+                        className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm transition-colors ${
+                          checked[i]
+                            ? "bg-fuchsia-600 text-white"
+                            : "bg-white/5 text-white/80 hover:bg-white/10"
+                        }`}
+                      >
+                        <span className="w-5 shrink-0 text-center font-bold">
+                          {checked[i] ? "✓" : String(i + 1)}
+                        </span>
+                        <span>{answer}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ol>
+
+                {/* Submit — only once timer has ended */}
+                {timerDone && (
+                  <TextureButton variant="primary" onClick={handleSubmit}>
+                    Submit Score: {score} / 10
+                  </TextureButton>
+                )}
+              </div>
+            )}
+          </TextureCard>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -27,9 +27,12 @@ const initialState: GameState = {
   gameMode: "local",
   showWinModal: false,
   showQuestionModal: false,
+  showCultureModal: false,
   showEditor: false,
   showSettings: false,
   answerResult: null,
+  cultureTimerStartedAt: null,
+  cultureScore: null,
 };
 
 function gameReducer(state: GameState, action: GameAction): GameState {
@@ -150,6 +153,9 @@ function gameReducer(state: GameState, action: GameAction): GameState {
         usedQuestionIds: new Set<string>(),
         showWinModal: false,
         showQuestionModal: false,
+        showCultureModal: false,
+        cultureTimerStartedAt: null as null,
+        cultureScore: null as null,
       };
       if (action.mode === "online") {
         return { ...state, ...modeReset, gameMode: action.mode, players: [] };
@@ -177,6 +183,9 @@ function gameReducer(state: GameState, action: GameAction): GameState {
         usedQuestionIds: new Set(),
         showWinModal: false,
         showQuestionModal: false,
+        showCultureModal: false,
+        cultureTimerStartedAt: null,
+        cultureScore: null,
       };
 
     case "SET_QUESTIONS":
@@ -191,6 +200,23 @@ function gameReducer(state: GameState, action: GameAction): GameState {
 
     case "SHOW_QUESTION_MODAL":
       return { ...state, showQuestionModal: action.show };
+
+    case "SHOW_CULTURE_MODAL":
+      if (!action.show) {
+        return {
+          ...state,
+          showCultureModal: false,
+          cultureTimerStartedAt: null,
+          cultureScore: null,
+        };
+      }
+      return { ...state, showCultureModal: true };
+
+    case "SET_CULTURE_TIMER_START":
+      return { ...state, cultureTimerStartedAt: action.startedAt };
+
+    case "SET_CULTURE_SCORE":
+      return { ...state, cultureScore: action.score };
 
     case "SHOW_EDITOR":
       return { ...state, showEditor: action.show };

--- a/src/context/GameLogicContext.tsx
+++ b/src/context/GameLogicContext.tsx
@@ -6,6 +6,8 @@ interface GameLogicValue {
   handleAnswer: (selectedIndex: number) => { correct: boolean; correctIndex: number } | undefined;
   afterAnswer: (correct: boolean) => void;
   handleSkip: () => void;
+  handleCultureScore: (score: number) => void;
+  triggerTileAt: (position: number) => void;
   diceState: DiceState;
   triggerDiceAnimation: (roll: number, onComplete: () => void) => void;
   processRoll: (roll: number) => void;

--- a/src/data/culture.json
+++ b/src/data/culture.json
@@ -1,0 +1,162 @@
+[
+  {
+    "id": "culture-001",
+    "question": "Name the Top 10 highest-grossing films starring Christian Bale",
+    "answers": [
+      "The Dark Knight Rises",
+      "The Dark Knight",
+      "Thor: Love and Thunder",
+      "Batman Begins",
+      "American Hustle",
+      "Ford v Ferrari",
+      "The Big Short",
+      "The Fighter",
+      "Vice",
+      "Exodus: Gods and Kings"
+    ]
+  },
+  {
+    "id": "culture-002",
+    "question": "Name the Top 10 best-selling video game franchises of all time",
+    "answers": [
+      "Mario",
+      "Tetris",
+      "Call of Duty",
+      "FIFA / EA Sports FC",
+      "Pokémon",
+      "Grand Theft Auto",
+      "Need for Speed",
+      "The Sims",
+      "Madden NFL",
+      "Minecraft"
+    ]
+  },
+  {
+    "id": "culture-003",
+    "question": "Name the Top 10 most-streamed artists on Spotify of all time",
+    "answers": [
+      "Ed Sheeran",
+      "Drake",
+      "The Weeknd",
+      "Bad Bunny",
+      "Taylor Swift",
+      "Justin Bieber",
+      "Ariana Grande",
+      "Rihanna",
+      "Eminem",
+      "BTS"
+    ]
+  },
+  {
+    "id": "culture-004",
+    "question": "Name the Top 10 highest-grossing movie franchises of all time",
+    "answers": [
+      "Marvel Cinematic Universe",
+      "Star Wars",
+      "Harry Potter / Wizarding World",
+      "James Bond",
+      "The Lord of the Rings / The Hobbit",
+      "X-Men",
+      "Fast & Furious",
+      "Transformers",
+      "Batman",
+      "Spider-Man"
+    ]
+  },
+  {
+    "id": "culture-005",
+    "question": "Name the Top 10 most-watched TV shows on Netflix of all time",
+    "answers": [
+      "Squid Game",
+      "Wednesday",
+      "Stranger Things (Season 4)",
+      "The Night Agent",
+      "Ginny & Georgia (Season 2)",
+      "The Glory",
+      "Outer Banks (Season 3)",
+      "You (Season 4)",
+      "La Reina del Sur (Season 3)",
+      "Kaleidoscope"
+    ]
+  },
+  {
+    "id": "culture-006",
+    "question": "Name the Top 10 best-selling albums of all time",
+    "answers": [
+      "Thriller — Michael Jackson",
+      "Back in Black — AC/DC",
+      "The Dark Side of the Moon — Pink Floyd",
+      "Bat Out of Hell — Meat Loaf",
+      "Their Greatest Hits — Eagles",
+      "Rumours — Fleetwood Mac",
+      "Come On Over — Shania Twain",
+      "Led Zeppelin IV — Led Zeppelin",
+      "The Bodyguard — Soundtrack",
+      "Falling into You — Celine Dion"
+    ]
+  },
+  {
+    "id": "culture-007",
+    "question": "Name the Top 10 highest-paid athletes in the world in 2024",
+    "answers": [
+      "Cristiano Ronaldo",
+      "Jon Rahm",
+      "Lionel Messi",
+      "LeBron James",
+      "Lamar Jackson",
+      "Giannis Antetokounmpo",
+      "Canelo Álvarez",
+      "Stephen Curry",
+      "Anthony Joshua",
+      "Roger Federer"
+    ]
+  },
+  {
+    "id": "culture-008",
+    "question": "Name the Top 10 most-followed accounts on Instagram",
+    "answers": [
+      "Instagram",
+      "Cristiano Ronaldo",
+      "Lionel Messi",
+      "Selena Gomez",
+      "Kylie Jenner",
+      "Dwayne Johnson",
+      "Ariana Grande",
+      "Kim Kardashian",
+      "Beyoncé",
+      "Khloé Kardashian"
+    ]
+  },
+  {
+    "id": "culture-009",
+    "question": "Name the Top 10 highest-rated IMDb TV shows of all time",
+    "answers": [
+      "Breaking Bad",
+      "Planet Earth II",
+      "Band of Brothers",
+      "Chernobyl",
+      "Our Planet",
+      "Game of Thrones (Season 4)",
+      "The Wire",
+      "Avatar: The Last Airbender",
+      "The Sopranos",
+      "Sherlock"
+    ]
+  },
+  {
+    "id": "culture-010",
+    "question": "Name the Top 10 best-selling books of all time",
+    "answers": [
+      "Don Quixote",
+      "A Tale of Two Cities",
+      "The Lord of the Rings",
+      "The Little Prince",
+      "Harry Potter and the Philosopher's Stone",
+      "And Then There Were None",
+      "Dream of the Red Chamber",
+      "The Hobbit",
+      "She: A History of Adventure",
+      "The Lion, the Witch and the Wardrobe"
+    ]
+  }
+]

--- a/src/firebase/roomService.ts
+++ b/src/firebase/roomService.ts
@@ -160,7 +160,22 @@ export async function advanceTurn(roomCode: string): Promise<void> {
     currentQuestion: null,
     currentRoll: null,
     answerResult: null,
+    cultureEvent: null,
   });
+}
+
+export async function activateCulture(roomCode: string): Promise<void> {
+  await set(ref(db, `rooms/${roomCode}/cultureEvent`), { active: true });
+}
+
+export async function startCultureTimer(roomCode: string): Promise<void> {
+  await update(ref(db, `rooms/${roomCode}/cultureEvent`), {
+    timerStartedAt: Date.now(),
+  });
+}
+
+export async function submitCultureScore(roomCode: string, score: number): Promise<void> {
+  await update(ref(db, `rooms/${roomCode}/cultureEvent`), { score });
 }
 
 export async function clearTurnState(roomCode: string): Promise<void> {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -45,6 +45,9 @@ export const CATEGORY_BG_COLORS: Record<Category, string> = {
   history: "bg-cat-history",
 };
 
+export const CULTURE_POSITIONS = new Set([10, 20, 30]);
+export const CULTURE_TIMER_SECONDS = 30;
+
 export const MOVE_DURATION = 500;
 
 export const GRID_SIZE = 7;

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -39,9 +39,12 @@ export interface GameState {
   gameMode: GameMode;
   showWinModal: boolean;
   showQuestionModal: boolean;
+  showCultureModal: boolean;
   showEditor: boolean;
   showSettings: boolean;
   answerResult: AnswerResult | null;
+  cultureTimerStartedAt: number | null;
+  cultureScore: number | null;
 }
 
 export interface OnlineIdentity {
@@ -63,6 +66,7 @@ export interface RoomData {
   } | null;
   gameState: "waiting" | "playing";
   resetId?: number;
+  cultureEvent: { active: boolean; timerStartedAt?: number; score?: number } | null;
 }
 
 export type GameAction =
@@ -92,4 +96,7 @@ export type GameAction =
       players: Player[];
       currentPlayerIndex: number;
     }
-  | { type: "SET_ANSWER_RESULT"; result: AnswerResult | null };
+  | { type: "SET_ANSWER_RESULT"; result: AnswerResult | null }
+  | { type: "SHOW_CULTURE_MODAL"; show: boolean }
+  | { type: "SET_CULTURE_TIMER_START"; startedAt: number | null }
+  | { type: "SET_CULTURE_SCORE"; score: number | null };


### PR DESCRIPTION
- culture.json: 10 Top-10 questions for culture tiles
- Cell.tsx: culture tiles now display star + "Culture" label
- CultureModal.tsx: deterministic question selection, checkbox answer tracking, 2-phase flow (waiting/timer), synced timer via Firebase timerStartedAt, score result screen shown to all clients before movement, active player Continue button triggers movement
- roomService.ts: startCultureTimer writes timerStartedAt to Firebase
- hooks.ts: dispatches SET_CULTURE_TIMER_START and SET_CULTURE_SCORE to all clients; removes onCultureScore callback (handled via state)
- GameContext/types: cultureTimerStartedAt + cultureScore state fields
- SettingsMenu.tsx: debug teleport with tile trigger (triggerTileAt)
- useGameLogic.ts: triggerTileAt fires correct tile effect at any position, handles online mode via Firebase writes